### PR TITLE
neo4j-python-driver 4.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.4" %}
+{% set version = "4.3.5" %}
 
 package:
   name: neo4j-python-driver
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/neo4j/neo4j-python-driver/archive/{{ version }}.tar.gz
-  sha256: a3a8c182debb8f697e960d74f0ec80d6812cb2ada9a18816deeac6575db7e0ed
+  sha256: e3872d5ec99dda0d8087036a9d27134e42a18ff42d720fb1045e66945049da3a
 
 build:
   number: 0


### PR DESCRIPTION
Update neo4j-python-driver to 4.3.5