### PR TITLE
neo4j-python-driver 4.3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.4" %}
+{% set version = "4.3.6" %}
 
 package:
   name: neo4j-python-driver
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/neo4j/neo4j-python-driver/archive/{{ version }}.tar.gz
-  sha256: a3a8c182debb8f697e960d74f0ec80d6812cb2ada9a18816deeac6575db7e0ed
+  sha256: 1c69c072853ee1f21419ba9fda5c3d3cbd58b5a3ace5576a517e13d04e7dc82e
 
 build:
   number: 0


### PR DESCRIPTION
Update neo4j-python-driver to 4.3.6