### PR TITLE
neo4j-python-driver 4.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.4" %}
+{% set version = "4.4.0" %}
 
 package:
   name: neo4j-python-driver
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/neo4j/neo4j-python-driver/archive/{{ version }}.tar.gz
-  sha256: a3a8c182debb8f697e960d74f0ec80d6812cb2ada9a18816deeac6575db7e0ed
+  sha256: 1c63513674b047d9cfcac950225069364af7ae1ccc504d4c696566a626fb3ed0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
Update neo4j-python-driver to 4.4.0

Version change: bump version number from 4.3.4 to 4.4.0
Bug Tracker: new open issues https://github.com/neo4j/neo4j-python-driver/issues
Upstream Changelog: https://github.com/neo4j/neo4j-python-driver/blob/5.0/CHANGELOG.md
License: https://github.com/neo4j/neo4j-python-driver/blob/5.0/LICENSE.txt

Actions:
1. Skip py<36

Result:
- all-succeeded