### PR TITLE
neo4j-python-driver 4.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.4.0" %}
+{% set version = "4.4.2" %}
 
 package:
   name: neo4j-python-driver
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/neo4j/neo4j-python-driver/archive/{{ version }}.tar.gz
-  sha256: 1c63513674b047d9cfcac950225069364af7ae1ccc504d4c696566a626fb3ed0
+  sha256: 1d1acca6678f52591f9e7769ce71aea4934ec875a7b454a95382b053a44941ac
 
 build:
   number: 0


### PR DESCRIPTION
Update neo4j-python-driver to 4.4.2