### PR TITLE
Update 5.27.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   skip: True  # [py<38]
-  script: python -m pip install --no-deps --ignore-installed .
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
   build:
@@ -40,6 +40,8 @@ about:
   license: Apache-2.0
   license_file: LICENSE.txt
   license_family: Apache
+  description: |
+    The official Neo4j driver for Python. 
   summary: 'Database connector for Neo4j graph database'
   dev_url: https://github.com/neo4j/neo4j-python-driver
   doc_url: https://neo4j.com/docs/api/python-driver/current/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,6 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vvv
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - pytz
   run_constrained:
     - pandas >=1.1.0,<3.0.0
-    - numpy >=1.7.0 < 3.0.0
+    - numpy >=1.7.0, < 3.0.0
     - pyarrow >=1.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,9 +24,9 @@ requirements:
     - python
     - pytz
   run_constrained:
-    - pandas
-    - numpy
-    - pyarrow
+    - pandas >=1.1.0,<3.0.0
+    - numpy >=1.7.0 < 3.0.0
+    - pyarrow >=1.0.0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.4.0" %}
+{% set version = "5.27.0" %}
 
 package:
   name: neo4j-python-driver
@@ -6,11 +6,11 @@ package:
 
 source:
   url: https://github.com/neo4j/neo4j-python-driver/archive/{{ version }}.tar.gz
-  sha256: 1c63513674b047d9cfcac950225069364af7ae1ccc504d4c696566a626fb3ed0
+  sha256: cefd4296efe564b2feb96f628699e0cbf421888ba5815a1b92b2c1b5e71ff07d
 
 build:
   number: 0
-  skip: True  # [py<36]
+  skip: True  # [py<38]
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:
@@ -18,9 +18,9 @@ requirements:
     - {{ compiler('c') }}
   host:
     - python
-    - cython
     - pip
     - setuptools
+    - tomlkit
     - wheel
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,10 @@ requirements:
   run:
     - python
     - pytz
+  run_constrained:
+    - pandas
+    - numpy
+    - pyarrow
 
 test:
   imports:
@@ -39,7 +43,7 @@ about:
   license_file: LICENSE.txt
   license_family: Apache
   description: |
-    The official Neo4j driver for Python. 
+    The official Neo4j driver for Python.
   summary: 'Database connector for Neo4j graph database'
   dev_url: https://github.com/neo4j/neo4j-python-driver
   doc_url: https://neo4j.com/docs/api/python-driver/current/


### PR DESCRIPTION
> ## ☆ Neo4j-python-driver 5.27.0 ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-6240) 
[Upstream](https://github.com/neo4j/neo4j-python-driver/tree/5.27.0)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run` and `host` 
