### PR TITLE
Add generated anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,7 +1,7 @@
 anaconda_config_version: 1
 upstream_sources:
-  - pypi:
-      identifier: neo4j-driver
+  - github:
+      identifier: neo4j/neo4j-python-driver
     packages:
       - neo4j
       - neo4j-driver


### PR DESCRIPTION
This PR adds generated `anaconda.yaml` (Feedstock Configuration Format).

See the reason https://github.com/AnacondaRecipes/neo4j-python-driver-feedstock/blob/master/recipe/meta.yaml#L9